### PR TITLE
fix ISO 3166-2:AT

### DIFF
--- a/TCDev.Utilities/Country/Counties.cs
+++ b/TCDev.Utilities/Country/Counties.cs
@@ -22,7 +22,7 @@ public static class Counties
             {
                {"DE-BW", "Baden-Württemberg"}, {"DE-BY", "Bayern"}, {"DE-BE", "Berlin"}, {"DE-BB", "Brandenburg"}, {"DE-HB", "Bremen"}, {"DE-HH", "Hamburg"}, {"DE-HE", "Hessen"}, {"DE-MV", "Mecklenburg-Vorpommern"}, {"DE-NI", "Niedersachsen"}, {"DE-NW", "Nordrhein-Westfalen"}, {"DE-RP", "Rheinland-Pfalz"}, {"DE-SL", "Saarland"}, {"DE-SN", "Sachsen"}, {"DE-ST", "Sachsen-Anhalt"}, {"DE-SH", "Schleswig-Holstein"}, {"DE-TH", "Thüringen"}
             };
-         case CountryCode.AU:
+         case CountryCode.AT:
             return new Dictionary<string, string>
             {
                {"AT-1", "Burgenland"}, //Burgenland


### PR DESCRIPTION
_ISO 3166-2:AT_ lookup was mapped from the `CountryCode` of _Australia_ instead of _Austria_